### PR TITLE
Fix broken URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository keeps the configuration to build your own equalstreetnames-berlin, which is based on [equalstreetnames](https://github.com/openknowledgebe/equalstreetnames).
 
-See it online at [https://umap.openstreetmap.de/equalstreetnames-berlin](https://umap.openstreetmap.de/equalstreetnames-berlin)
+See it online at [https://umap.openstreetmap.de/equalstreetnames-berlin/de/index.html](https://umap.openstreetmap.de/equalstreetnames-berlin/de/index.html)
 
 The map shows OpenStreetMap ways of type "highway", "place" and "leisure" and relations of type "associatedStreet" (which is unwanted in Germany but still there) and "street". See [overpass querys](https://github.com/gislars/equalstreetnames-berlin/blob/master/overpass/way-full-json) for details.
 


### PR DESCRIPTION
- Invoking the URL without the trailing slash results in an HTTP 404 error page.